### PR TITLE
Making sure view is re-rendered when new text is set

### DIFF
--- a/FBDigitalFont/Classes/FBBitmapFontView.m
+++ b/FBDigitalFont/Classes/FBBitmapFontView.m
@@ -46,6 +46,7 @@
 {
     _text = text;
     self.symbols = [FBFontSymbol symbolsForString:text];
+    [self setNeedsDisplay];
 }
 
 - (void)resetSize

--- a/FBDigitalFont/Classes/FBLCDFontView.m
+++ b/FBDigitalFont/Classes/FBLCDFontView.m
@@ -47,6 +47,7 @@
 {
     _text = text;
     self.symbols = [FBFontSymbol symbolsForString:text];
+    [self setNeedsDisplay];
 }
 
 - (void)resetSize

--- a/FBDigitalFont/Classes/FBSquareFontView.m
+++ b/FBDigitalFont/Classes/FBSquareFontView.m
@@ -46,6 +46,7 @@
 {
     _text = text;
     self.symbols = [FBFontSymbol symbolsForString:text];
+    [self setNeedsDisplay];
 }
 
 - (void)resetSize


### PR DESCRIPTION
When setting the text of a view, the view doesn't render the new value.
To get the view to execute it's rendering method (drawRect:) you must call setNeedsDisplay right after setting the text.

So to avoid code repetition I added this to the setText: method of each one of the views.
