### PR TITLE
Fixed memory leak

### DIFF
--- a/FBDigitalFont/Classes/FBFontSymbol.m
+++ b/FBDigitalFont/Classes/FBFontSymbol.m
@@ -2,9 +2,18 @@
 
 @implementation FBFontSymbol
 
+static NSMutableArray *symbols;
+
 + (NSArray *)symbolsForString:(NSString *)str
 {
-    NSMutableArray *symbols = @[].mutableCopy;
+    //@[].mutableCopy is causing memory leaks because new arrays are getting created everytime it's refreshed.
+    //Only create symbols if it's nil, else remove all symbols and keep reusing the NSMutableArray.
+    if (symbols == nil) {
+        symbols = @[].mutableCopy;
+    } else {
+        [symbols removeAllObjects];
+    }
+    
     NSString *upper = [str uppercaseString];
     for (NSInteger i = 0; i < upper.length; i++) {
         NSString *c = [upper substringWithRange:NSMakeRange(i,1)];

--- a/FBDigitalFontDemo/FBDigitalFontDemo/FBViewController.m
+++ b/FBDigitalFontDemo/FBDigitalFontDemo/FBViewController.m
@@ -24,7 +24,7 @@
 @end
 
 @interface FBViewController ()
-
+@property(strong,nonatomic)FBBitmapFontView *bfv;
 @end
 
 @implementation FBViewController
@@ -37,25 +37,45 @@
     [self setupLCDFont];
     [self setupSquareFont];
     [self setupSquareFont2];
+    
+    [NSTimer scheduledTimerWithTimeInterval:1.0
+                                     target:self
+                                   selector:@selector(tick:)
+                                   userInfo:nil
+                                    repeats:YES];
+}
+
+-(void)tick:(NSTimer *)timer {
+    
+    self.bfv.text = [self time];
+}
+
+-(NSString*)time {
+    //do smth
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"hh:mm:ss"];
+    NSDate *date = [[NSDate alloc]init];
+    
+    return [dateFormatter stringFromDate:date];
 }
 
 
 - (void)setupBitmapFont
 {
     CGRect frame = CGRectMake(10, 60, 300, 50);
-    FBBitmapFontView *v = [[FBBitmapFontView alloc] initWithFrame:frame];
-    v.text = @"05:40:32";
-    v.dotType = FBFontDotTypeSquare;
-    v.numberOfBottomPaddingDot = 1;
-    v.numberOfTopPaddingDot    = 1;
-    v.numberOfLeftPaddingDot   = 2;
-    v.numberOfRightPaddingDot  = 2;
-    v.glowSize = 20.0;
-    v.innerGlowSize = 3.0;
-    v.edgeLength = 5.0;
-    [self.view addSubview:v];
-    [v resetSize];
-    [v centerizeInWidth:320];
+    self.bfv = [[FBBitmapFontView alloc] initWithFrame:frame];
+    self.bfv.text = [self time];
+    self.bfv.dotType = FBFontDotTypeSquare;
+    self.bfv.numberOfBottomPaddingDot = 1;
+    self.bfv.numberOfTopPaddingDot    = 1;
+    self.bfv.numberOfLeftPaddingDot   = 2;
+    self.bfv.numberOfRightPaddingDot  = 2;
+    self.bfv.glowSize = 20.0;
+    self.bfv.innerGlowSize = 3.0;
+    self.bfv.edgeLength = 5.0;
+    [self.view addSubview:self.bfv];
+    [self.bfv resetSize];
+    [self.bfv centerizeInWidth:320];
 }
 
 - (void)setupLCDFont


### PR DESCRIPTION
After profiling your code, I saw that you have a memory leak in your FBFontSymbol class at NSMutableArray *symbols = @[].mutableCopy;.  I changed your code to have the NSMutableArray be a singleton so that the array does not get created every time the FBFontSymbol gets used.  That seemed to have solved the issue without tampering too much with your code.  Please take a look at my git pull request and see if this makes sense when you run your memory leak profiler.

![screen shot 2014-02-11 at 9 39 47 pm](https://f.cloud.github.com/assets/38386/2145470/0f460f86-93a6-11e3-947e-50797b7b77bc.png)
